### PR TITLE
Plain Sign addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /public/meta.json
 /src/consts/consts.js
+/src/consts/consts
 *.zip
 
 # for now
@@ -15,6 +16,7 @@ package-lock.json
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/KeyInfoMessage.js
+++ b/src/KeyInfoMessage.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2020 Cryptogogue, Inc. All Rights Reserved.
 
 import { DecryptAndSignWithKeyModal }       from './DecryptAndSignWithKeyModal';
+import { SignWithKeyModal }                 from './SignWithKeyModal';
 import { EncryptWithKeyModal }              from './EncryptWithKeyModal';
 import { PasswordInputField }               from './PasswordInputField';
 import JSONTree                             from 'react-json-tree';
@@ -11,6 +12,7 @@ import * as UI                              from 'semantic-ui-react';
 const MODALS = {
     ENCRYPT:            'ENCRYPT',
     DECRYPT_AND_SIGN:   'DECRYPT_AND_SIGN',
+    SIGN:               'SIGN',
     EXPORT:             'EXPORT',
     ENTITLEMENTS:       'ENTITLEMENTS',
 };
@@ -155,6 +157,14 @@ export const KeyInfoMessage = observer (( props ) => {
                     />
                 </When>
 
+                <When condition = {( modal === MODALS.SIGN )}>
+                    <SignWithKeyModal
+                        accountService      = { accountService }
+                        keyName             = { keyName }
+                        onClose             = { onClose }
+                    />
+                </When>
+
                 <When condition = {( modal === MODALS.EXPORT )}>
                     <ExportKeyModal
                         accountService      = { accountService }
@@ -200,6 +210,7 @@ export const KeyInfoMessage = observer (( props ) => {
                     <UI.Dropdown.Menu>
                         <UI.Dropdown.Item icon = 'envelope'     text = 'Encrypt'            onClick = {() => { setModal ( MODALS.ENCRYPT ); }}/>
                         <UI.Dropdown.Item icon = 'signup'       text = 'Decrypt & Sign'     onClick = {() => { setModal ( MODALS.DECRYPT_AND_SIGN ); }}/>
+                        <UI.Dropdown.Item icon = 'address card' text = 'Sign'               onClick = {() => { setModal ( MODALS.SIGN ); }}/>
                         <UI.Dropdown.Item icon = 'unlock'       text = 'Export'             onClick = {() => { setModal ( MODALS.EXPORT ); }}/>
                         <UI.Dropdown.Item icon = 'shield'       text = 'Entitlements'       onClick = {() => { setModal ( MODALS.ENTITLEMENTS ); }}/>
                     </UI.Dropdown.Menu>

--- a/src/SignWithKeyModal.js
+++ b/src/SignWithKeyModal.js
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 Cryptogogue, Inc. All Rights Reserved.
+
+import { PasswordInputField }               from './PasswordInputField';
+import JSONTree                             from 'react-json-tree';
+import { observer }                         from 'mobx-react';
+import React, { useState }                  from 'react';
+import * as UI                              from 'semantic-ui-react';
+
+//================================================================//
+// DecryptAndSignWithKeyModal
+//================================================================//
+export const DecryptAndSignWithKeyModal = observer (( props ) => {
+
+    const { accountService, keyName, onClose }      = props;
+    const [ encoded, setEncoded ]                   = useState ( '' );
+    const [ password, setPassword ]                 = useState ( '' );
+    const [ passwordCount, setPasswordCount ]       = useState ( 0 );
+
+    const [ msgEnvelope, setMsgEnvelope ]           = useState ( false );
+    const [ plaintext, setPlaintext ]               = useState ( false );
+
+    const [ sigEnvelope, setSigEnvelope ]           = useState ( false );
+    const [ sigEncoded, setSigEncoded ]             = useState ( false );
+
+    const [ error, setError ]                       = useState ( false );
+
+    const appState      = accountService.appState;
+    const key           = accountService.account.keys [ keyName ];
+
+    const onChange = async ( event ) => {
+        setEncoded ( event.target.value );
+        setError ( false );
+    }
+
+    const onClickDecrypt = async () => {
+
+        const escaped = encoded.replace ( /(\r\n|\n|\r )/gm, '' );
+        const envelope = JSON.parse ( Buffer.from ( escaped, 'base64' ).toString ( 'utf8' ));
+
+        const keyPair       = await accountService.getKeyPairAsync ( keyName, password );
+        const plaintext     = keyPair.decrypt ( envelope.ciphertext, envelope.fromPublicHex );
+
+        setPasswordCount ( passwordCount + 1 );
+
+        if ( plaintext === false ) {
+            setError ( 'Could not decrypt with this key.' );
+            return;
+        }
+        setMsgEnvelope ( envelope );
+        setPlaintext ( plaintext );
+    }
+
+    const onClosePlaintextModal = () => {
+        setMsgEnvelope ( false );
+        setPlaintext ( false );
+        setPassword ( '' );
+    }
+
+    const onClickSign = async () => {
+
+        const keyPair       = await accountService.getKeyPairAsync ( keyName, password );
+        const signature     = keyPair.sign ( plaintext );
+
+        const envelope = {
+            publicHex:          accountService.account.keys [ keyName ].publicKeyHex,
+            messageID:          msgEnvelope.messageID,
+            signature:          signature,
+        }
+
+        const encoded = Buffer.from ( JSON.stringify ( envelope ), 'utf8' ).toString ( 'base64' );
+
+        setSigEnvelope ( envelope );
+        setSigEncoded ( encoded );
+    }
+
+    const onCloseSigModal = () => {
+        setSigEnvelope ( false );
+        setSigEncoded ( false );
+        onClosePlaintextModal ();
+    }
+
+    const canDecrypt = password && encoded;
+
+    return (
+        <React.Fragment>
+
+            {/******************************************************************
+                DECRYPT & SIGN MODAL
+            ******************************************************************/}
+            <UI.Modal
+                open
+                closeIcon
+                size        = 'small'
+                onClose     = {() => { onClose ()}}
+            >
+                <UI.Modal.Header>Sign</UI.Modal.Header>
+                <UI.Modal.Content>
+                    <UI.Form>
+                        <UI.Form.TextArea
+                            rows            = { 8 }
+                            value           = { plaintext }
+                            onChange        = { onChange }
+                            error           = { false }
+                            label           = 'String'
+                            error           = { error }
+                        />
+                        <PasswordInputField
+                            key             = { passwordCount }
+                            appState        = { appState }
+                            setPassword     = { setPassword }
+                        />
+                    </UI.Form>
+                </UI.Modal.Content>
+                <UI.Modal.Actions>
+                    <UI.Button
+                        positive
+                        <!--disabled    = { !canDecrypt }-->
+                        onClick     = { onClickSign }
+                    >
+                        Sign
+                    </UI.Button>
+                </UI.Modal.Actions>
+            </UI.Modal>
+
+            {/******************************************************************
+                PLAINTEXT MODAL
+            ******************************************************************/}
+            <UI.Modal
+                closeIcon
+                size        = 'small'
+                onClose     = { onClosePlaintextModal }
+                open        = { plaintext !== false }
+            >
+                <UI.Modal.Header>Message</UI.Modal.Header>
+                <UI.Modal.Content>
+                    <UI.Segment>
+                        { plaintext }
+                    </UI.Segment>
+                </UI.Modal.Content>
+                <UI.Modal.Actions>
+                    <UI.Button
+                        positive
+                        onClick     = { onClickSign }
+                    >
+                        Sign
+                    </UI.Button>
+                </UI.Modal.Actions>
+            </UI.Modal>
+
+            {/******************************************************************
+                SIGNATURE MODAL
+            ******************************************************************/}
+            <UI.Modal
+                closeIcon
+                size        = 'small'
+                onClose     = { onCloseSigModal }
+                open        = { sigEnvelope !== false }
+            >
+                <UI.Modal.Header>Signature</UI.Modal.Header>
+                <UI.Modal.Content>
+                    <UI.Segment>
+                        <JSONTree
+                            data                = { sigEnvelope }
+                            theme               = 'bright'
+                            shouldExpandNode    = {() => { return true; }}
+                        />
+
+                        <UI.Segment
+                            raised
+                            style = {{
+                                wordBreak: 'break-all',
+                                wordWrap: 'break-word',
+                                overflowWrap: 'break-word',
+                                fontFamily: 'monospace',
+                            }}
+                        >
+                            <UI.Header as = 'h3'>Base 64</UI.Header>
+                            { sigEncoded }
+                        </UI.Segment>
+                    </UI.Segment>
+                </UI.Modal.Content>
+            </UI.Modal>
+
+        </React.Fragment>
+    );
+});

--- a/src/SignWithKeyModal.js
+++ b/src/SignWithKeyModal.js
@@ -9,7 +9,7 @@ import * as UI                              from 'semantic-ui-react';
 //================================================================//
 // DecryptAndSignWithKeyModal
 //================================================================//
-export const DecryptAndSignWithKeyModal = observer (( props ) => {
+export const SignWithKeyModal = observer (( props ) => {
 
     const { accountService, keyName, onClose }      = props;
     const [ encoded, setEncoded ]                   = useState ( '' );
@@ -114,7 +114,6 @@ export const DecryptAndSignWithKeyModal = observer (( props ) => {
                 <UI.Modal.Actions>
                     <UI.Button
                         positive
-                        <!--disabled    = { !canDecrypt }-->
                         onClick     = { onClickSign }
                     >
                         Sign

--- a/src/SignWithKeyModal.js
+++ b/src/SignWithKeyModal.js
@@ -7,7 +7,7 @@ import React, { useState }                  from 'react';
 import * as UI                              from 'semantic-ui-react';
 
 //================================================================//
-// DecryptAndSignWithKeyModal
+// SignWitKeyModal
 //================================================================//
 export const SignWithKeyModal = observer (( props ) => {
 
@@ -17,7 +17,7 @@ export const SignWithKeyModal = observer (( props ) => {
     const [ passwordCount, setPasswordCount ]       = useState ( 0 );
 
     const [ msgEnvelope, setMsgEnvelope ]           = useState ( false );
-    const [ plaintext, setPlaintext ]               = useState ( false );
+    const [ plaintext, setPlaintext ]               = useState ( '' );
 
     const [ sigEnvelope, setSigEnvelope ]           = useState ( false );
     const [ sigEncoded, setSigEncoded ]             = useState ( false );
@@ -28,32 +28,8 @@ export const SignWithKeyModal = observer (( props ) => {
     const key           = accountService.account.keys [ keyName ];
 
     const onChange = async ( event ) => {
-        setEncoded ( event.target.value );
+        setPlaintext ( event.target.value );
         setError ( false );
-    }
-
-    const onClickDecrypt = async () => {
-
-        const escaped = encoded.replace ( /(\r\n|\n|\r )/gm, '' );
-        const envelope = JSON.parse ( Buffer.from ( escaped, 'base64' ).toString ( 'utf8' ));
-
-        const keyPair       = await accountService.getKeyPairAsync ( keyName, password );
-        const plaintext     = keyPair.decrypt ( envelope.ciphertext, envelope.fromPublicHex );
-
-        setPasswordCount ( passwordCount + 1 );
-
-        if ( plaintext === false ) {
-            setError ( 'Could not decrypt with this key.' );
-            return;
-        }
-        setMsgEnvelope ( envelope );
-        setPlaintext ( plaintext );
-    }
-
-    const onClosePlaintextModal = () => {
-        setMsgEnvelope ( false );
-        setPlaintext ( false );
-        setPassword ( '' );
     }
 
     const onClickSign = async () => {
@@ -79,13 +55,13 @@ export const SignWithKeyModal = observer (( props ) => {
         onClosePlaintextModal ();
     }
 
-    const canDecrypt = password && encoded;
+    const canSign = password && Boolean(plaintext);
 
     return (
         <React.Fragment>
 
             {/******************************************************************
-                DECRYPT & SIGN MODAL
+                SIGN MODAL
             ******************************************************************/}
             <UI.Modal
                 open
@@ -101,7 +77,7 @@ export const SignWithKeyModal = observer (( props ) => {
                             value           = { plaintext }
                             onChange        = { onChange }
                             error           = { false }
-                            label           = 'String'
+                            label           = 'String to sign'
                             error           = { error }
                         />
                         <PasswordInputField
@@ -114,31 +90,7 @@ export const SignWithKeyModal = observer (( props ) => {
                 <UI.Modal.Actions>
                     <UI.Button
                         positive
-                        onClick     = { onClickSign }
-                    >
-                        Sign
-                    </UI.Button>
-                </UI.Modal.Actions>
-            </UI.Modal>
-
-            {/******************************************************************
-                PLAINTEXT MODAL
-            ******************************************************************/}
-            <UI.Modal
-                closeIcon
-                size        = 'small'
-                onClose     = { onClosePlaintextModal }
-                open        = { plaintext !== false }
-            >
-                <UI.Modal.Header>Message</UI.Modal.Header>
-                <UI.Modal.Content>
-                    <UI.Segment>
-                        { plaintext }
-                    </UI.Segment>
-                </UI.Modal.Content>
-                <UI.Modal.Actions>
-                    <UI.Button
-                        positive
+                        disabled    = { !canSign }
                         onClick     = { onClickSign }
                     >
                         Sign
@@ -152,7 +104,7 @@ export const SignWithKeyModal = observer (( props ) => {
             <UI.Modal
                 closeIcon
                 size        = 'small'
-                onClose     = { onCloseSigModal }
+                onClose     = { onClose }
                 open        = { sigEnvelope !== false }
             >
                 <UI.Modal.Header>Signature</UI.Modal.Header>

--- a/src/consts/consts
+++ b/src/consts/consts
@@ -1,0 +1,3 @@
+/* eslint-disable no-whitespace-before-property */
+
+export const SERVICE_URL = 'http://localhost:7777';

--- a/src/consts/consts
+++ b/src/consts/consts
@@ -1,3 +1,0 @@
-/* eslint-disable no-whitespace-before-property */
-
-export const SERVICE_URL = 'http://localhost:7777';


### PR DESCRIPTION
This creates a new tool in the keys section to sign a plaintext message. It displays the same modal showed when a signature is generated using "Decrypt & Sign." I also added to the .gitignore to ignore IntelliJ's .idea directory and the src/consts/consts file which buggered me a couple times.